### PR TITLE
Ensure deploy-directory exists and explicitly state `--install`

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,10 +10,17 @@
 - name: install acme.sh
   become: True
   shell: INSTALLONLINE=1 /tmp/acme.sh
+           --install
            --home "{{ letsencrypt_base_dir }}"
   args:
     chdir: "/tmp"
   when: download.changed
+
+- name: Ensure deploy-directory exists
+  file:
+    path: "{{ letsencrypt_base_dir }}/deploy"
+    state: directory
+  become: true
 
 - name: install deploy scripts
   become: True


### PR DESCRIPTION
In this role the version of acme is not fixed. With the new version of acme the role fails on machines where the role has not been rolled out before. This MR fixes this.