### PR TITLE
Set default CA back to letsencrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role to setup Let's Encrypt certificates
 |letsencrypt_reloadcmd|Empty|Command to execute after installing new certificates (if installing)|
 |letsencrypt_deploy|Empty|Hooks to use (if using deploy mode)|
 |letsencrypt_force|`False`|Force-renew certificate. Useful when switching from staging to production|
+|letsencrypt_default_ca|`letsencrypt`|Default CA that will be used to issue the certificate. May be changed to e.g. `zerossl` to avoid rate limits but requires registration|
 
 ### Issurance modes
 For certificate issurance, this role supports a "standalone" mode, where a

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,4 @@ letsencrypt_deploy:
   staging_hook: ""
 
 letsencrypt_force: False
+letsencrypt_default_ca: letsencrypt

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,3 +33,10 @@
     - freeipa_staging
     - ejabberd
     - mailserver
+
+- name: Set default CA
+  become: True
+  command: >
+    {{ letsencrypt_base_dir }}/acme.sh
+      --set-default-ca --server "{{ letsencrypt_default_ca }}"
+  when: letsencrypt_default_ca is defined and download.changed


### PR DESCRIPTION
acme.sh was updated and now uses zerossl as default CA, this however requires a registration with an email and makes this role fail if this is not done manually (https://github.com/acmesh-official/acme.sh/wiki/ZeroSSL.com-CA).

This PR adds the option to configure the default CA and defaults to `letsencrypt` so the role does the same it did in the past (https://github.com/acmesh-official/acme.sh/wiki/Server).

If it is preferred to use the new acme.sh default zerossl, I can e.g. comment-out the new variable so it is not set and the default-ca will not be changed.