### PR TITLE
Complete renaming of issueW to issue_web and issueS to issue_standalone

### DIFF
--- a/tasks/freeipa.yml
+++ b/tasks/freeipa.yml
@@ -29,4 +29,4 @@
     DIRMAN_PASSWORD: "{{ freeipa_secrets.dm_password }}"
     DIRSRV_INSTANCE: "{{ letsencrypt_deploy.dirsrv_instance }}"
   changed_when: false
-  when: letsencrypt_install_mode == "deploy" and (issueW.changed or issueS.changed)
+  when: letsencrypt_install_mode == "deploy" and (issue_web.changed or issue_standalone.changed)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
       --fullchain-file "{{ letsencrypt_install.fullchain_path }}"
       --reloadcmd "{{ letsencrypt_reloadcmd }}"
   changed_when: false
-  when: letsencrypt_install_mode == "install" and issueW.changed
+  when: letsencrypt_install_mode == "install" and issue_web.changed
 
 - name: Deploy the certificate
   become: true
@@ -42,7 +42,7 @@
   changed_when: false
   when:
     - letsencrypt_install_mode == "deploy"
-    - issueW.changed or issueS.changed
+    - issue_web.changed or issue_standalone.changed
     - letsencrypt_deploy.hook != "freeipa"
     - letsencrypt_deploy.staging_hook != "freeipa_staging"
 


### PR DESCRIPTION
In commit `6456322` some of the `issueW` and `issueS` variables were renamed in `tasks/issue.yml`. They are also referenced in `tasks/main.yml` and `tasks/freeipa.yml` but were not renamed.