### PR TITLE
Install socat when in standalone mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,11 @@
 ---
+- name: Install socat
+  become: true
+  ansible.builtin.apt:
+    name: socat
+    state: present
+  when: letsencrypt_issue_mode == "standalone"
+
 - name: Download acme.sh
   become: true
   ansible.builtin.get_url:


### PR DESCRIPTION
acme.sh needs socat if in standalone mode (https://github.com/acmesh-official/acme.sh/issues/1005).