### PR TITLE
Add renewhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role to setup Let's Encrypt certificates
 |letsencrypt_issue_mode|`webroot`| Whether to use `webroot` or `standalone` mode (see below)|
 |letsencrypt_install_mode|`install`| Whether to `install` or `deploy` the certificate |
 |letsencrypt_webroot|`/var/www/letsencrypt`|The directory to use as webroot (if using webroot mode)|
-|letsencrypt_issue|empty|Pre/post commands for certificate issurance|
+|letsencrypt_issue|empty|Pre/post/renew commands for certificate issurance|
 |letsencrypt_install|see defaults/main.yml|Where to install the certificate to (if installing)|
 |letsencrypt_reloadcmd|Empty|Command to execute after installing new certificates (if installing)|
 |letsencrypt_deploy|Empty|Hooks to use (if using deploy mode)|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ letsencrypt_webroot: "/var/www/letsencrypt"
 letsencrypt_issue:
   prehook: ""
   posthook: ""
+  renewhook: ""
 
 letsencrypt_install:
   cert_path: "/etc/ssl/certs/{{ letsencrypt_domain | replace('.', '_') }}.cer"

--- a/tasks/issue.yml
+++ b/tasks/issue.yml
@@ -10,6 +10,7 @@
       -w "{{ letsencrypt_webroot }}"
       --pre-hook "{{ letsencrypt_issue.prehook }}"
       --post-hook "{{ letsencrypt_issue.posthook }}"
+      --renew-hook "{{ letsencrypt_issue.renewhook }}"
   register: issue_web
   failed_when: issue_web.rc == 1
   changed_when: issue_web.rc == 0
@@ -27,6 +28,7 @@
       --httpport {{ letsencrypt_port }}
       --pre-hook "{{ letsencrypt_issue.prehook }}"
       --post-hook "{{ letsencrypt_issue.posthook }}"
+      --renew-hook "{{ letsencrypt_issue.renewhook }}"
   register: issue_standalone
   failed_when: issue_standalone.rc == 1
   changed_when: issue_standalone.rc == 0


### PR DESCRIPTION
In standalone mode the certs are not installed and thus `reloadcommand` cannot be used. This PR adds the option to define a `renewhook` which is executed each time the certs are renewed.

https://github.com/acmesh-official/acme.sh/wiki/Using-pre-hook-post-hook-renew-hook-reloadcmd